### PR TITLE
Editorial: fix a few Markdown errors

### DIFF
--- a/IPR Policy.md
+++ b/IPR Policy.md
@@ -24,7 +24,7 @@ All [Contributors][contributor] make commitments regarding copyrights; all [Cont
 #### 2.2.2. "Essential Review Draft Claims"
 "Essential Review Draft Claims", with respect to a [Review Draft][review-draft], means all claims in any patent or patent application in any jurisdiction in the world that would necessarily be infringed by implementation of the [Review Draft][review-draft]. A claim is necessarily infringed hereunder only when it is not possible to avoid infringing it because there is no non-infringing alternative for implementation of the [Normative] portions of the [Review Draft][review-draft]. Existence of a non-infringing alternative shall be judged based on the state of the art at the time the [Review Draft][review-draft] is published.
 
-#### 2.2.3. The following are expressly excluded from and shall not be deemed to constitute [Essential Patent Claims]:
+#### 2.2.3. The following are expressly excluded from and shall not be deemed to constitute Essential Patent Claims:
 1. any claims other than as set forth in "[Essential Contribution Claims]" or "[Essential Review Draft Claims]" even if contained in the same patent as [Essential Patent Claims]; and
 
 2. claims which would be infringed only by:

--- a/SG Agreement.md
+++ b/SG Agreement.md
@@ -70,7 +70,7 @@ By <a id="unanimous-consent">**unanimous consent**</a>, the [Steering Group] may
 
 4. Add a [Steering Group Member].
 
-5. Remove a [Steering Group Member] (where the [Steering Group Member] at issue is not counted for
+5. Remove a [Steering Group Member] \(where the [Steering Group Member] at issue is not counted for
   purposes of determining unanimity).
 
 6. Amend this [Agreement].

--- a/Workstream Policy.md
+++ b/Workstream Policy.md
@@ -191,7 +191,7 @@ Pending" or "Under Discussion".
 
 [Editors][Editor] are responsible for the technical content of their [Workstreams][Workstream], and
 accordingly have sole authority to modify WHATWG documents in the [Workstream] for which they serve
-as [Editor] (e.g., to adopt or adapt [Contributions], including their own; accept pull requests;
+as [Editor] \(e.g., to adopt or adapt [Contributions], including their own; accept pull requests;
 etc.), and to publish the associated [Living Standard], periodic [Review Drafts][review-draft], and documentation
 (if any).
 
@@ -254,7 +254,7 @@ the [Editor] regarding adoption of [Contributions] and modifications to the [Liv
 #### Appeals
 
 [Workstream Participants] may raise substantive issues for resolution by the [Steering Group] if not
-resolved within the [Workstream] (e.g., [scope][Workstream Scope], direction, [Editor] decisions, and participation).
+resolved within the [Workstream] \(e.g., [scope][Workstream Scope], direction, [Editor] decisions, and participation).
 
 1. To raise an issue formally for review by the [Editor] and other [Workstream Participants], a [Workstream Participant][Workstream Participants] must:
    1. Identify the issue clearly (technical problem, interoperability issue, delta from [Workstream Scope], inconsistency with the [WHATWG Principles], etc.) and recommend a solution;
@@ -267,8 +267,8 @@ resolved within the [Workstream] (e.g., [scope][Workstream Scope], direction, [E
 
 #### Removal
 
-The [Steering Group] may remove a [Workstream Participant][Workstream Participants] [Entity] or individual.
-For example, the [Steering Group] may remove a [Workstream Participant] for a violation of the WHATWG [Code of Conduct], for failure to comply with the [Contributor and Workstream Participant Agreement], or not complying with the [IPR Policy].
+The [Steering Group] may remove a [Workstream Participant][Workstream Participants], [Entity], or individual.
+For example, the [Steering Group] may remove a [Workstream Participant][Workstream Participants] for a violation of the WHATWG [Code of Conduct], for failure to comply with the [Contributor and Workstream Participant Agreement], or not complying with the [IPR Policy].
 The [Steering Group]'s determination in each instance is final and non-appealable.
 
 ## Publications
@@ -291,7 +291,7 @@ In the text above, "Living Standard Review Draft" must link to the latest [Revie
 [Living Standard Review Drafts][review-draft] must include the following notice, including the link:
 > Copyright © YEAR WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
 
-In the text above, YEAR must be replaced by the current year at the time the [Living Standard Review Draft] is published.
+In the text above, YEAR must be replaced by the current year at the time the [Living Standard Review Draft][review-draft] is published.
 
 In addition, [Living Standard Review Drafts][review-draft] must include the following notice:
 > This is the Review Draft. It is published primarily for purposes of patent review by Workstream Participants; it mirrors the Living Standard closely, redacting only text that is identified as "Objection Pending" or "Confirmation Pending". Developers should refer to the Living Standard for the most current error corrections and other developments.


### PR DESCRIPTION
These are all issues where the Markdown in question is unfriendly to the HTML-conversion script, or where a link was inadvertently forgotten, leaving brackets in the source. Found by grepping the generated output for "[".