### PR TITLE
Editorial: use Oxford comma in Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The WHATWG Steering Group
 
-The purpose of the [Steering Group](./SG%20Agreement.md#def-steering-group) 
+The purpose of the [Steering Group](./SG%20Agreement.md#def-steering-group)
 is to govern and guide the [WHATWG](https://whatwg.org) to be an open, efficient forum for
 development of Living Standards and other materials that relate to or support web technologies.  It
 maintains policies and addresses issues that arise to ensure that the WHATWG develops useful
@@ -20,7 +20,7 @@ Living Standards.
 
 ## Code of conduct
 
-We are committed to providing a friendly, safe and welcoming environment for all. Please read and
+We are committed to providing a friendly, safe, and welcoming environment for all. Please read and
 respect the [WHATWG Code of Conduct](https://whatwg.org/code-of-conduct).
 
 

--- a/code-of-conduct
+++ b/code-of-conduct
@@ -27,7 +27,7 @@
   member of the community you feel you can trust.
 
   <ul>
-   <li><p>We are committed to providing a friendly, safe and welcoming environment for all,
+   <li><p>We are committed to providing a friendly, safe, and welcoming environment for all,
    regardless of level of experience, gender, gender identity and expression, sexual orientation,
    disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other
    similar characteristic.
@@ -37,7 +37,7 @@
    <li><p>Respect that people have differences of opinion and that every design or implementation
    choice carries a trade-off and numerous costs. There is seldom a right answer.
 
-   <li><p>You shall not insult, demean or harass anyone. We interpret the term "harassment" as
+   <li><p>You shall not insult, demean, or harass anyone. We interpret the term "harassment" as
    including the definition in the
    <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; if you have any lack of
    clarity about what might be included in that concept, please read their definition. In
@@ -48,11 +48,11 @@
    immediately. Whether you're a regular contributor or a newcomer, we care about making this
    community a safe place for you and we've got your back.
 
-   <li><p>Likewise any spamming, trolling, flaming, baiting or other attention-stealing behaviour is
-   not welcome.
+   <li><p>Likewise any spamming, trolling, flaming, baiting, or other attention-stealing behaviour
+   is not welcome.
 
    <li><p>Avoid using overtly sexual nicknames or other nicknames that might detract from a
-   friendly, safe and welcoming environment for all.
+   friendly, safe, and welcoming environment for all.
   </ul>
 
   <h3 id="moderation">Moderation<a class="self-link" href="#moderation"></a></h3>


### PR DESCRIPTION
This makes it consistent with https://wiki.whatwg.org/wiki/Style.