### PR TITLE
Give guidance for LICENSE files in repositories

### DIFF
--- a/Workstream Policy.md
+++ b/Workstream Policy.md
@@ -323,6 +323,15 @@ case-by-case basis by the [Steering Group].
 The repositories for all WHATWG publications and other deliverables
 must include the text of the applicable license in a LICENSE file.
 
+The contents of the license file should be
+> Copyright © YEAR WHATWG (Apple, Google, Mozilla, Microsoft).
+> This work is licensed under a Creative Commons Attribution 4.0 International License:
+
+Where YEAR is the current year, and followed by the full text of the
+Creative Commons Attribution 4.0 International License in plaintext.
+
+The SG repository has an example of how to do this correctly in its [LICENSE file](./LICENSE).
+
 ## Antitrust
 
 The WHATWG is a forum for voluntary development and promotion of standards, specifications,

--- a/Workstream Policy.md
+++ b/Workstream Policy.md
@@ -323,12 +323,13 @@ case-by-case basis by the [Steering Group].
 The repositories for all WHATWG publications and other deliverables
 must include the text of the applicable license in a LICENSE file.
 
-The contents of the license file should be
+The contents of the license file must start with:
 > Copyright © YEAR WHATWG (Apple, Google, Mozilla, Microsoft).
 > This work is licensed under a Creative Commons Attribution 4.0 International License:
 
-Where YEAR is the current year, and followed by the full text of the
-Creative Commons Attribution 4.0 International License in plaintext.
+where YEAR is the current year. This copyright notice must be followed
+by the full text of the Creative Commons Attribution 4.0 International
+License in plaintext.
 
 The SG repository has an example of how to do this correctly in its [LICENSE file](./LICENSE).
 

--- a/policy-link-mapping.txt
+++ b/policy-link-mapping.txt
@@ -5,3 +5,4 @@
 ./Principles.md=principles
 ./Workstreams.md=https://github.com/whatwg/sg/blob/master/Workstreams.md
 ./ThirdPartyNotices/W3CLicenses.md=https://github.com/whatwg/sg/blob/master/ThirdPartyNotices/W3CLicenses.md
+./LICENSE=https://github.com/whatwg/sg/blob/master/LICENSE


### PR DESCRIPTION
- Fixes #51
- Also links to the SG repo's LICENSE file as an example
- Updates policy-link-mapping,txt so the link still works on whatwg.org