### PR TITLE
Update whatwg.org docs

### DIFF
--- a/code-of-conduct
+++ b/code-of-conduct
@@ -1,99 +1,103 @@
-<!doctype html>
+<!DOCTYPE HTML>
 <html lang="en">
- <head>
-  <title>Web Hypertext Application Technology Working Group Code of Conduct</title>
-  <link rel="stylesheet" href="/style/tabbed-pages">
-  <link rel="icon" href="https://resources.whatwg.org/logo.svg">
- </head>
- <body>
+<meta charset="utf-8">
+<title>Code of Conduct — WHATWG</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#3A7908">
+<link rel="icon" href="https://resources.whatwg.org/logo.svg">
+<link rel="stylesheet" href="/style/shared.css">
+<link rel="stylesheet" href="/style/subpages.css">
+
+<header>
+ <hgroup>
   <h1>
-   <span class="the">The</span>
-   <strong class="what">Web Hypertext Application Technology</strong>
-   <span class="wg">Working Group</span>
+   <a href="/">
+    <img id="main-logo" src="https://resources.whatwg.org/logo.svg" alt="">
+    WHATWG
+   </a>
   </h1>
-  <ul class="navigation">
-   <li><a href="/" rel="home">Home</a></li>
-   <li><a href="https://spec.whatwg.org/">Standards</a></li>
-   <li><a href="/faq">FAQ</a></li>
-   <li><a href="/policies">Policies</a></li>
-   <li><a href="https://participate.whatwg.org/">Participate</a></li>
-  </ul>
-
   <h2>Code of Conduct</h2>
+ </hgroup>
+</header>
 
-  <h3 id="conduct">Conduct<a class="self-link" href="#conduct"></a></h3>
+<nav class="buttonish-links">
+ <a href="https://spec.whatwg.org/">Standards</a>
+ <a href="/faq">FAQ</a>
+ <a href="/policies">Policies</a>
+ <a href="https://participate.whatwg.org/">Participate</a>
+</nav>
 
-  <p>Contact: the WHATWG Steering Group, via <a href="mailto:sg@whatwg.org">sg@whatwg.org</a>, or a
-  member of the community you feel you can trust.
+<h3 id="conduct">Conduct<a class="self-link" href="#conduct"></a></h3>
 
-  <ul>
-   <li><p>We are committed to providing a friendly, safe, and welcoming environment for all,
-   regardless of level of experience, gender, gender identity and expression, sexual orientation,
-   disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other
-   similar characteristic.
+<p>Contact: the WHATWG Steering Group, via <a href="mailto:sg@whatwg.org">sg@whatwg.org</a>, or a
+member of the community you feel you can trust.
 
-   <li><p>Please be kind and courteous. There's no need to be mean or rude.
+<ul>
+ <li><p>We are committed to providing a friendly, safe, and welcoming environment for all,
+ regardless of level of experience, gender, gender identity and expression, sexual orientation,
+ disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other
+ similar characteristic.
 
-   <li><p>Respect that people have differences of opinion and that every design or implementation
-   choice carries a trade-off and numerous costs. There is seldom a right answer.
+ <li><p>Please be kind and courteous. There's no need to be mean or rude.
 
-   <li><p>You shall not insult, demean, or harass anyone. We interpret the term "harassment" as
-   including the definition in the
-   <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; if you have any lack of
-   clarity about what might be included in that concept, please read their definition. In
-   particular, we don't tolerate behavior that excludes people in socially marginalized groups.
+ <li><p>Respect that people have differences of opinion and that every design or implementation
+ choice carries a trade-off and numerous costs. There is seldom a right answer.
 
-   <li><p>This includes private harassment. No matter who you are, if you feel you have been or are
-   being harassed or made uncomfortable by a community member, please let the contact know
-   immediately. Whether you're a regular contributor or a newcomer, we care about making this
-   community a safe place for you and we've got your back.
+ <li><p>You shall not insult, demean, or harass anyone. We interpret the term "harassment" as
+ including the definition in the
+ <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; if you have any lack of
+ clarity about what might be included in that concept, please read their definition. In
+ particular, we don't tolerate behavior that excludes people in socially marginalized groups.
 
-   <li><p>Likewise any spamming, trolling, flaming, baiting, or other attention-stealing behaviour
-   is not welcome.
+ <li><p>This includes private harassment. No matter who you are, if you feel you have been or are
+ being harassed or made uncomfortable by a community member, please let the contact know
+ immediately. Whether you're a regular contributor or a newcomer, we care about making this
+ community a safe place for you and we've got your back.
 
-   <li><p>Avoid using overtly sexual nicknames or other nicknames that might detract from a
-   friendly, safe, and welcoming environment for all.
-  </ul>
+ <li><p>Likewise any spamming, trolling, flaming, baiting, or other attention-stealing behaviour
+ is not welcome.
 
-  <h3 id="moderation">Moderation<a class="self-link" href="#moderation"></a></h3>
+ <li><p>Avoid using overtly sexual nicknames or other nicknames that might detract from a
+ friendly, safe, and welcoming environment for all.
+</ul>
 
-  <p>These are the policies for upholding the WHATWG Code of Conduct:
+<h3 id="moderation">Moderation<a class="self-link" href="#moderation"></a></h3>
 
-  <ul>
-   <li><p>Remarks that violate the WHATWG Code of Conduct, including hateful, hurtful, oppressive,
-   or exclusionary remarks, are not allowed. (Cursing is allowed on IRC, but never targeting another
-   user, and never in a hateful manner.)
+<p>These are the policies for upholding the WHATWG Code of Conduct:
 
-   <li><p>Remarks that moderators find inappropriate, whether listed in the code of conduct or not,
-   are also not allowed.
+<ul>
+ <li><p>Remarks that violate the WHATWG Code of Conduct, including hateful, hurtful, oppressive,
+ or exclusionary remarks, are not allowed. (Cursing is allowed on IRC, but never targeting another
+ user, and never in a hateful manner.)
 
-   <li><p>If you think an action of a moderator was unjustified, please take it up with that
-   moderator, or with a different moderator, in private. Complaints about bans in-channel are not
-   allowed.
+ <li><p>Remarks that moderators find inappropriate, whether listed in the code of conduct or not,
+ are also not allowed.
 
-   <li><p>Moderators are held to a higher standard than other community members. If a moderator
-   creates an inappropriate situation, they should expect less leeway than others.
-  </ul>
+ <li><p>If you think an action of a moderator was unjustified, please take it up with that
+ moderator, or with a different moderator, in private. Complaints about bans in-channel are not
+ allowed.
 
-  <p>In the WHATWG community we strive to go the extra step to look out for each other. Don't just
-  aim to be technically unimpeachable; try to be your best self. In particular, avoid flirting with
-  offensive or sensitive issues, particularly if they're off-topic; this all too often leads to
-  unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the
-  community entirely.
+ <li><p>Moderators are held to a higher standard than other community members. If a moderator
+ creates an inappropriate situation, they should expect less leeway than others.
+</ul>
 
-  <p>And if someone takes issue with something you said or did, resist the urge to be defensive.
-  Just stop doing what it was they complained about and apologize. Even if you feel you were
-  misinterpreted or unfairly accused, chances are good there was something you could've communicated
-  better — remember that it's your responsibility to make your fellow contributors comfortable.
-  Everyone wants to get along and we are all here first and foremost because we want to talk about
-  standards and everything that involves. You will find that people will be eager to assume good
-  intent and forgive as long as you earn their trust.
+<p>In the WHATWG community we strive to go the extra step to look out for each other. Don't just
+aim to be technically unimpeachable; try to be your best self. In particular, avoid flirting with
+offensive or sensitive issues, particularly if they're off-topic; this all too often leads to
+unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the
+community entirely.
 
-  <p><small>Adapted from
-  <a href="https://www.rust-lang.org/conduct.html">The Rust Code of Conduct</a>.</small>
+<p>And if someone takes issue with something you said or did, resist the urge to be defensive.
+Just stop doing what it was they complained about and apologize. Even if you feel you were
+misinterpreted or unfairly accused, chances are good there was something you could've communicated
+better — remember that it's your responsibility to make your fellow contributors comfortable.
+Everyone wants to get along and we are all here first and foremost because we want to talk about
+standards and everything that involves. You will find that people will be eager to assume good
+intent and forgive as long as you earn their trust.
 
-  <footer>
-   <p><small>Copyright © 2018 WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</small></p>
-  </footer>
- </body>
-</html>
+<p><small>Adapted from
+<a href="https://www.rust-lang.org/conduct.html">The Rust Code of Conduct</a>.</small>
+
+<footer>
+ <p><small>Copyright © 2018 WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</small></p>
+</footer>

--- a/working-mode
+++ b/working-mode
@@ -1,288 +1,292 @@
-<!doctype html>
+<!DOCTYPE HTML>
 <html lang="en">
- <head>
-  <title>Web Hypertext Application Technology Working Group Working Mode</title>
-  <link rel="stylesheet" href="/style/tabbed-pages">
-  <link rel="icon" href="https://resources.whatwg.org/logo.svg">
- </head>
- <body>
+<meta charset="utf-8">
+<title>Working Mode — WHATWG</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#3A7908">
+<link rel="icon" href="https://resources.whatwg.org/logo.svg">
+<link rel="stylesheet" href="/style/shared.css">
+<link rel="stylesheet" href="/style/subpages.css">
+
+<header>
+ <hgroup>
   <h1>
-   <span class="the">The</span>
-   <strong class="what">Web Hypertext Application Technology</strong>
-   <span class="wg">Working Group</span>
+   <a href="/">
+    <img id="main-logo" src="https://resources.whatwg.org/logo.svg" alt="">
+    WHATWG
+   </a>
   </h1>
-  <ul class="navigation">
-   <li><a href="/" rel="home">Home</a></li>
-   <li><a href="https://spec.whatwg.org/">Standards</a></li>
-   <li><a href="/faq">FAQ</faq></li>
-   <li><a href="/policies">Policies</a></li>
-   <li><a href="https://participate.whatwg.org/">Participate</a></li>
-  </ul>
-
   <h2>Working Mode</h2>
+ </hgroup>
+</header>
 
-  <p>The WHATWG develops standards and assists in maintaining their corresponding tests, thereby
-  fostering independent implementations. The WHATWG adheres to a shared
-  <a href="https://wiki.whatwg.org/wiki/Code_of_Conduct">Code of Conduct</a>.
+<nav class="buttonish-links">
+ <a href="https://spec.whatwg.org/">Standards</a>
+ <a href="/faq">FAQ</a>
+ <a href="/policies">Policies</a>
+ <a href="https://participate.whatwg.org/">Participate</a>
+</nav>
 
-  <p>While discussing and working on standards, it’s always useful to keep these questions in mind:
+<p>The WHATWG develops standards and assists in maintaining their corresponding tests, thereby
+fostering independent implementations. The WHATWG adheres to a shared
+<a href="/code-of-conduct">Code of Conduct</a>.
 
-  <ul>
-   <li>What do implementations do?
+<p>While discussing and working on standards, it’s always useful to keep these questions in mind:
 
-   <li>What do the tests reveal?
+<ul>
+ <li>What do implementations do?
 
-   <li>What should the processing model look like?
-  </ul>
+ <li>What do the tests reveal?
 
-  <h3 id="standard">Standard<a class="self-link" href="#standard"></a></h3>
+ <li>What should the processing model look like?
+</ul>
 
-  <p>Each standard (ideally) has:
+<h3 id="standard">Standard<a class="self-link" href="#standard"></a></h3>
 
-  <ul>
-   <li>An active community of contributors.
+<p>Each standard (ideally) has:
 
-   <li>An assigned editor and zero or more deputy editors.
+<ul>
+ <li>An active community of contributors.
 
-   <li>A changelog. (A tidy Git repository with linear history.)
+ <li>An assigned editor and zero or more deputy editors.
 
-   <li>An issue tracker.
+ <li>A changelog. (A tidy Git repository with linear history.)
 
-   <li>Corresponding tests.
-  </ul>
+ <li>An issue tracker.
 
-  <h4 id="editor">Editor<a class="self-link" href="#editor"></a></h4>
+ <li>Corresponding tests.
+</ul>
 
-  <p>The editor has the following responsibilities, all of which can be delegated to deputy editors:
+<h4 id="editor">Editor<a class="self-link" href="#editor"></a></h4>
 
-  <ul>
-   <li>Ensure any applied changes fulfill the relevant criteria for changes.
+<p>The editor has the following responsibilities, all of which can be delegated to deputy editors:
 
-   <li>Resolve conflicts between contributors.
+<ul>
+ <li>Ensure any applied changes fulfill the relevant criteria for changes.
 
-   <li>Reduce open issues.
+ <li>Resolve conflicts between contributors.
 
-   <li>Help manage the corresponding tests.
+ <li>Reduce open issues.
 
-   <li>Ensure implementations follow the standard and vice versa. (The “don’t write fiction” rule.)
-  </ul>
+ <li>Help manage the corresponding tests.
 
-  <h3 id="issues">Issues<a class="self-link" href="#issues"></a></h3>
+ <li>Ensure implementations follow the standard and vice versa. (The “don’t write fiction” rule.)
+</ul>
 
-  <h4 id="normative-issues">Normative issues<a class="self-link" href="#normative-issues"></a></h4>
+<h3 id="issues">Issues<a class="self-link" href="#issues"></a></h3>
 
-  <p>Problems with the standard are generally recorded as issues. Resolving an issue typically
-  involves answering these questions:
+<h4 id="normative-issues">Normative issues<a class="self-link" href="#normative-issues"></a></h4>
 
-  <ul>
-   <li>What do implementations do?
+<p>Problems with the standard are generally recorded as issues. Resolving an issue typically
+involves answering these questions:
 
-   <li>What is the ideal behavior?
+<ul>
+ <li>What do implementations do?
 
-   <li>What is the lowest cost towards convergence? (Counting lowest number of implementations that
-   would have to change as the cheapest solution.)
+ <li>What is the ideal behavior?
 
-   <li>What do implementations want to do?
-  </ul>
+ <li>What is the lowest cost towards convergence? (Counting lowest number of implementations that
+ would have to change as the cheapest solution.)
 
-  <p>It’s not always possible to get the answers to all these questions in a timely manner.
-  Therefore, it might be the case that a decision is made even without input from all parties. This
-  makes it very important to file bugs for any spec changes (as discussed below), as a final check
-  to make sure all implementers are on board with, or at least aware of, the change.
+ <li>What do implementations want to do?
+</ul>
 
-  <p>Additions to the standard can also be proposed as issues. However, the process for turning such
-  an issue into an accepted change to the standard is generally more involved, as the criteria for
-  additions is stricter (see <a href="#additions">Additions</a>). A typical path for turning such
-  issues into accepted changes is detailed in the <a href="#new-proposals">New Proposals</a>
-  section.
+<p>It’s not always possible to get the answers to all these questions in a timely manner.
+Therefore, it might be the case that a decision is made even without input from all parties. This
+makes it very important to file bugs for any spec changes (as discussed below), as a final check
+to make sure all implementers are on board with, or at least aware of, the change.
 
-  <h4 id="non-normative-issues">Non-normative
-  issues<a class="self-link" href="#non-normative-issues"></a></h4>
+<p>Additions to the standard can also be proposed as issues. However, the process for turning such
+an issue into an accepted change to the standard is generally more involved, as the criteria for
+additions is stricter (see <a href="#additions">Additions</a>). A typical path for turning such
+issues into accepted changes is detailed in the <a href="#new-proposals">New Proposals</a>
+section.
 
-  <p>Changes of editorial nature can be made, accepted, or rejected by the editor without
-  discussion.
+<h4 id="non-normative-issues">Non-normative
+issues<a class="self-link" href="#non-normative-issues"></a></h4>
 
-  <h3 id="changes">Changes<a class="self-link" href="#changes"></a></h3>
+<p>Changes of editorial nature can be made, accepted, or rejected by the editor without
+discussion.
 
-  <p>Each normative change made to the standard needs to meet the following criteria:
+<h3 id="changes">Changes<a class="self-link" href="#changes"></a></h3>
 
-  <ul>
-   <li>It must have support from implementers.
+<p>Each normative change made to the standard needs to meet the following criteria:
 
-   <li>It should have corresponding test changes, either in the form of new tests or modifications
-   to existing tests.
+<ul>
+ <li>It must have support from implementers.
 
-   <li>Implementations bugs must be filed for each user agent that fails tests. (This is each user
-   agent that doesn’t match the proposed changes. If the test changes are not adequate to reveal
-   that, but it’s known through other means, the tests should be improved first.)
+ <li>It should have corresponding test changes, either in the form of new tests or modifications
+ to existing tests.
 
-   <li>It should have been reviewed by one or more members of the community.
+ <li>Implementations bugs must be filed for each user agent that fails tests. (This is each user
+ agent that doesn’t match the proposed changes. If the test changes are not adequate to reveal
+ that, but it’s known through other means, the tests should be improved first.)
 
-   <li>Optional or implementation-defined behavior must be very well motivated.
-  </ul>
+ <li>It should have been reviewed by one or more members of the community.
 
-  <p>Additionally, the following more mechanical criteria are used to hone a change before accepting
-  it:
+ <li>Optional or implementation-defined behavior must be very well motivated.
+</ul>
 
-  <ul>
-   <li>It should match the standard’s source formatting and style conventions. (Consistent
-   formatting helps new contributors know what to do.)
+<p>Additionally, the following more mechanical criteria are used to hone a change before accepting
+it:
 
-   <li>It must have a good commit message, with at the minimum a title, but typically with a body
-   that includes pointers to relevant discussion, tests changes, and a more elaborate description of
-   the change. (A detailed commit message helps folks in the future figure out why a decision was
-   made. This happens a lot more than you might imagine.)
-  </ul>
+<ul>
+ <li>It should match the standard’s source formatting and style conventions. (Consistent
+ formatting helps new contributors know what to do.)
 
-  <p class="note">If the change is proposed by a new contributor, the editor can ensure the commit
-  message is good, and help with formatting and style. There’s no need to make new contributors jump
-  through too many hoops.
+ <li>It must have a good commit message, with at the minimum a title, but typically with a body
+ that includes pointers to relevant discussion, tests changes, and a more elaborate description of
+ the change. (A detailed commit message helps folks in the future figure out why a decision was
+ made. This happens a lot more than you might imagine.)
+</ul>
 
-  <h4 id="additions">Additions<a class="self-link" href="#additions"></a></h4>
+<p class="note">If the change is proposed by a new contributor, the editor can ensure the commit
+message is good, and help with formatting and style. There’s no need to make new contributors jump
+through too many hoops.
 
-  <p>Any change that represents an addition needs to meet these additional criteria:
+<h4 id="additions">Additions<a class="self-link" href="#additions"></a></h4>
 
-  <ul>
-   <li>The addition must have the support of at least two implementers. (Such support is not binding
-   in any way on the implementers, however.)
-  </ul>
+<p>Any change that represents an addition needs to meet these additional criteria:
 
-  <p>Additionally, the following are strongly recommended:
+<ul>
+ <li>The addition must have the support of at least two implementers. (Such support is not binding
+ in any way on the implementers, however.)
+</ul>
 
-  <ul>
-   <li>The support from implementers should be of the form “we would like to implement this soon”
-   and not just “this seems like a reasonable idea”.
+<p>Additionally, the following are strongly recommended:
 
-   <li>There should be no strong implementer objections to the new feature.
+<ul>
+ <li>The support from implementers should be of the form “we would like to implement this soon”
+ and not just “this seems like a reasonable idea”.
 
-   <li>There should already be a prototype implementation or one being worked on side-by-side with
-   the change to the standard.
+ <li>There should be no strong implementer objections to the new feature.
 
-   <li>New features should be something that cannot be done today or are such a common trend in
-   libraries that standardizing them helps lots of people. Alternatively, the “new” feature could
-   actually be a legacy feature that was not yet standardized, which is now being standardized.
-   (Legacy features are often hard to remove due to web compatibility; standardizing and testing
-   them helps improve interoperability and enables competition and refactoring.)
-  </ul>
+ <li>There should already be a prototype implementation or one being worked on side-by-side with
+ the change to the standard.
 
-  <h4 id="removals">Removals<a class="self-link" href="#removals"></a></h4>
+ <li>New features should be something that cannot be done today or are such a common trend in
+ libraries that standardizing them helps lots of people. Alternatively, the “new” feature could
+ actually be a legacy feature that was not yet standardized, which is now being standardized.
+ (Legacy features are often hard to remove due to web compatibility; standardizing and testing
+ them helps improve interoperability and enables competition and refactoring.)
+</ul>
 
-  <p>Any change that represents a removal needs to meet these additional criteria:
+<h4 id="removals">Removals<a class="self-link" href="#removals"></a></h4>
 
-  <ul>
-   <li><p>The feature being removed must either be not widely implemented, or must in the process of
-   being removed from implementations.
+<p>Any change that represents a removal needs to meet these additional criteria:
 
-   <li>
-    <p>A test ensuring the feature is not supported must be added and existing tests for the feature
-    should be adjusted or removed as appropriate.
+<ul>
+ <li><p>The feature being removed must either be not widely implemented, or must in the process of
+ being removed from implementations.
 
-    <p class="example"><a href="https://github.com/w3c/web-platform-tests/pull/5001">w3c/web-platform-tests#5001</a>
-    added new tests that appcache was not supported in shared workers, per the removal in
-    <a href="https://github.com/whatwg/html/pull/2384">whatwg/html#2384</a>.
+ <li>
+  <p>A test ensuring the feature is not supported must be added and existing tests for the feature
+  should be adjusted or removed as appropriate.
 
-    <p class="example">Adjusting existing tests can be difficult. If necessary, an issue can be
-    filed instead to track updating those tests. This was done in
-    <a href="https://github.com/w3c/web-platform-tests/issues/5053">w3c/web-platform-tests#5053</a>
-    which accompanied the removal in
-    <a href="https://github.com/whatwg/html/pull/2402">whatwg/html#2402</a>.
-  </ul>
+  <p class="example"><a href="https://github.com/w3c/web-platform-tests/pull/5001">w3c/web-platform-tests#5001</a>
+  added new tests that appcache was not supported in shared workers, per the removal in
+  <a href="https://github.com/whatwg/html/pull/2384">whatwg/html#2384</a>.
 
-  <h3 id="new-proposals">New Proposals<a class="self-link" href="#new-proposals"></a></h3>
+  <p class="example">Adjusting existing tests can be difficult. If necessary, an issue can be
+  filed instead to track updating those tests. This was done in
+  <a href="https://github.com/w3c/web-platform-tests/issues/5053">w3c/web-platform-tests#5053</a>
+  which accompanied the removal in
+  <a href="https://github.com/whatwg/html/pull/2402">whatwg/html#2402</a>.
+</ul>
 
-  <p>As described above, the criteria for inclusion in a WHATWG standard is rather strict. In the
-  initial stages of feature development for the web platform, such widespread implementer support is
-  often not available, or the shape of a feature is not yet clear enough for implementers to feel
-  comfortable pledging their support.
+<h3 id="new-proposals">New Proposals<a class="self-link" href="#new-proposals"></a></h3>
 
-  <p>In such scenarios we anticipate features will be “incubated” outside of WHATWG standards. This
-  could be in a variety of venues, such as:
+<p>As described above, the criteria for inclusion in a WHATWG standard is rather strict. In the
+initial stages of feature development for the web platform, such widespread implementer support is
+often not available, or the shape of a feature is not yet clear enough for implementers to feel
+comfortable pledging their support.
 
-  <ul>
-   <li><p>Another standards organization
+<p>In such scenarios we anticipate features will be “incubated” outside of WHATWG standards. This
+could be in a variety of venues, such as:
 
-   <li><p>A personal document or GitHub repository
+<ul>
+ <li><p>Another standards organization
 
-   <li><p>A pull request to a WHATWG standard, with the understanding it will not be merged until
-   the criteria above are met
+ <li><p>A personal document or GitHub repository
 
-   <li>
-    <p>A document hosted by the WHATWG, but not under the spec.whatwg.org subdomain and not titled
-    “Living Standard”
+ <li><p>A pull request to a WHATWG standard, with the understanding it will not be merged until
+ the criteria above are met
 
-    <p class="example">The
-    <a href="https://wiki.whatwg.org/wiki/CanvasColorSpace">CanvasColorSpace</a> proposal is being
-    incubated on the <a href="https://wiki.whatwg.org/">WHATWG Wiki</a>.
-  </ul>
+ <li>
+  <p>A document hosted by the WHATWG, but not under the spec.whatwg.org subdomain and not titled
+  “Living Standard”
 
-  <p>In all cases, features that hope to graduate to a WHATWG standard should strive to follow the
-  above guidelines, gather appropriate implementer commitments, and have corresponding tests.
+  <p class="example">The
+  <a href="https://wiki.whatwg.org/wiki/CanvasColorSpace">CanvasColorSpace</a> proposal is being
+  incubated on the <a href="https://wiki.whatwg.org/">WHATWG Wiki</a>.
+</ul>
 
-  <p>Additionally, those maintaining such proposals should try to involve the WHATWG community, for
-  example by filing an issue on the standard they anticipate eventually becoming a part of.
+<p>In all cases, features that hope to graduate to a WHATWG standard should strive to follow the
+above guidelines, gather appropriate implementer commitments, and have corresponding tests.
 
-  <p class="note">Overall, this process of incubation can be very lightweight, such as filing a pull
-  request on the appropriate WHATWG standard with a proposal, and gathering appropriate implementer
-  support there. Or it could be more involved, such as creating a separate repository at another
-  venue and iterating for a long time there.
+<p>Additionally, those maintaining such proposals should try to involve the WHATWG community, for
+example by filing an issue on the standard they anticipate eventually becoming a part of.
 
-  <p class="example">The addition of <code>URL.prototype.toJSON()</code> was rather straightforward
-  once a plan was agreed upon and upstream IDL issues were resolved:
-  <a href="https://github.com/whatwg/url/issues/137">whatwg/url#137</a>.
+<p class="note">Overall, this process of incubation can be very lightweight, such as filing a pull
+request on the appropriate WHATWG standard with a proposal, and gathering appropriate implementer
+support there. Or it could be more involved, such as creating a separate repository at another
+venue and iterating for a long time there.
 
-  <p class="example"><code>innerText</code> was initially drafted in a
-  <a href="https://github.com/rocallahan/innerText-spec">repository outside</a> the HTML Standard.
-  Integration into HTML then went rather smoothly:
-  <a href="https://github.com/whatwg/html/pull/1678">whatwg/html#1678</a>.
+<p class="example">The addition of <code>URL.prototype.toJSON()</code> was rather straightforward
+once a plan was agreed upon and upstream IDL issues were resolved:
+<a href="https://github.com/whatwg/url/issues/137">whatwg/url#137</a>.
 
-  <h3 id="tests">Tests<a class="self-link" href="#tests"></a></h3>
+<p class="example"><code>innerText</code> was initially drafted in a
+<a href="https://github.com/rocallahan/innerText-spec">repository outside</a> the HTML Standard.
+Integration into HTML then went rather smoothly:
+<a href="https://github.com/whatwg/html/pull/1678">whatwg/html#1678</a>.
 
-  <p>As discussed in <a href="#changes">Changes</a>, normative changes to a WHATWG standard requires
-  tests, usually submitted to
-  <a href="https://github.com/w3c/web-platform-tests">web-platform-tests</a>. At a high level, these
-  tests should strive to:
+<h3 id="tests">Tests<a class="self-link" href="#tests"></a></h3>
 
-  <ul>
-   <li>Be automated
+<p>As discussed in <a href="#changes">Changes</a>, normative changes to a WHATWG standard requires
+tests, usually submitted to
+<a href="https://github.com/w3c/web-platform-tests">web-platform-tests</a>. At a high level, these
+tests should strive to:
 
-   <li>Test error handling
+<ul>
+ <li>Be automated
 
-   <li>Test limits and edge cases, such as overflow outside the expected value set
-  </ul>
+ <li>Test error handling
 
-  <h3 id="conflicts">Conflicts<a class="self-link" href="#conflicts"></a></h3>
+ <li>Test limits and edge cases, such as overflow outside the expected value set
+</ul>
 
-  <p>In case of a conflict among the community of contributors, the editor is expected to go to
-  significant length to resolve disagreements. In the end, they make a judgment call to pick the
-  best option they believe will have multi-implementer support.
+<h3 id="conflicts">Conflicts<a class="self-link" href="#conflicts"></a></h3>
 
-  <p>If a workstream participant believes the editor's choice will not have multi-implementer
-  support, and they cannot convince the editor, then they may formally appeal to the Steering Group.
-  In their capacity as implementers, the Steering Group may correct or uphold the editor's decision.
+<p>In case of a conflict among the community of contributors, the editor is expected to go to
+significant length to resolve disagreements. In the end, they make a judgment call to pick the
+best option they believe will have multi-implementer support.
 
-  <p>Implementations can always override the editor by implementing something else. Whenever that
-  happens a breakdown in communication has taken place that the community should seek to overcome
-  and find ways to prevent it from happening again.
+<p>If a workstream participant believes the editor's choice will not have multi-implementer
+support, and they cannot convince the editor, then they may formally appeal to the Steering Group.
+In their capacity as implementers, the Steering Group may correct or uphold the editor's decision.
 
-  <p>Implementations that disagree can be rather tricky to sort out. Generally, we try to approach
-  these situations as follows:
+<p>Implementations can always override the editor by implementing something else. Whenever that
+happens a breakdown in communication has taken place that the community should seek to overcome
+and find ways to prevent it from happening again.
 
-  <ul>
-   <li>Find a solution that is mutually acceptable.
+<p>Implementations that disagree can be rather tricky to sort out. Generally, we try to approach
+these situations as follows:
 
-   <li>Research expectations of existing web content and specify the most web-compatible approach.
+<ul>
+ <li>Find a solution that is mutually acceptable.
 
-   <li>Align with the majority.
-  </ul>
+ <li>Research expectations of existing web content and specify the most web-compatible approach.
 
-  <p class="note">A standard is a tool towards convergence, and changing a standard can often be a
-  pragmatic solution in case of conflict.
+ <li>Align with the majority.
+</ul>
 
-  <p>Implementation disagreement should not result in implementation-defined behavior or optional
-  features.
+<p class="note">A standard is a tool towards convergence, and changing a standard can often be a
+pragmatic solution in case of conflict.
 
-  <footer>
-   <p><small>Copyright © 2018 WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</small></p>
-  </footer>
- </body>
-</html>
+<p>Implementation disagreement should not result in implementation-defined behavior or optional
+features.
+
+<footer>
+ <p><small>Copyright © 2018 WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</small></p>
+</footer>

--- a/working-mode
+++ b/working-mode
@@ -194,7 +194,7 @@ through too many hoops.
   <a href="https://github.com/whatwg/html/pull/2402">whatwg/html#2402</a>.
 </ul>
 
-<h3 id="new-proposals">New Proposals<a class="self-link" href="#new-proposals"></a></h3>
+<h3 id="new-proposals">New proposals<a class="self-link" href="#new-proposals"></a></h3>
 
 <p>As described above, the criteria for inclusion in a WHATWG standard is rather strict. In the
 initial stages of feature development for the web platform, such widespread implementer support is


### PR DESCRIPTION
The main content of this is syncing working-mode and code-of-conduct back from whatwg.org. We accidentally made editorial changes to these documents in the whatwg.org repository, instead of properly making them here and then syncing them over. This will hopefully be solved soon by whatwg/whatwg.org#133. In the meantime, perform this manual sync.

The changes were made in:

* whatwg/whatwg.org@4d34512 (site redesign)
* whatwg/whatwg.org@0b93777 (fixes a link)