### PR TITLE
Editorial: do not use link syntax for email

### DIFF
--- a/Code of Conduct.md
+++ b/Code of Conduct.md
@@ -2,7 +2,7 @@
 
 ## Conduct
 
-Contact: the WHATWG Steering Group, via [sg@whatwg.org](mailto:sg@whatwg.org), or a member of the community you feel you can trust.
+Contact: the WHATWG Steering Group, via sg@whatwg.org, or a member of the community you feel you can trust.
 
 * We are committed to providing a friendly, safe, and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 * Please be kind and courteous. There's no need to be mean or rude.


### PR DESCRIPTION
This results in erroneous HTML as discovered at https://github.com/whatwg/whatwg.org/pull/255. When displayed on GitHub the email will still present as a link.