### PR TITLE
Update SG representatives for Google and Microsoft.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ The Steering Group has adopted the following additional policies:
 
 * L. David Baron (Mozilla) [@dbaron](https://github.com/dbaron)
 * Maciej Stachowiak (Apple) [@othermaciej](https://github.com/othermaciej)
-* Michael Champion (Microsoft) [@michaelchampion](https://github.com/michaelchampion)
-* Shruthi Sreekanta (Google) [@henceproved](https://github.com/henceproved)
+* Philip Jägenstedt (Google) [@foolip](https://github.com/foolip)
+* Travis Leithead (Microsoft) [@travisleithead](https://github.com/travisleithead)


### PR DESCRIPTION
Google and Microsoft have both had (or are having) transitions of their SG representatives.  This should be documented here.  I'm requesting review from both old and new SG representatives in both cases.

The list *appears* to be alphabetical by whole name (in practice, by first name).  At least, I think that looks like the logic.