### PR TITLE
Editorial: CommonMark syntax for email address

### DIFF
--- a/Code of Conduct.md
+++ b/Code of Conduct.md
@@ -2,7 +2,7 @@
 
 ## Conduct
 
-Contact: the WHATWG Steering Group, via sg@whatwg.org, or a member of the community you feel you can trust.
+Contact: the WHATWG Steering Group, via <sg@whatwg.org>, or a member of the community you feel you can trust.
 
 * We are committed to providing a friendly, safe, and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 * Please be kind and courteous. There's no need to be mean or rude.


### PR DESCRIPTION
I missed in 81d78b807ddb3d23e8cdafd10094ade0f2c0e0b4 that angle brackets are important. SG Policy.md does this correctly. (GitHub does not care, but CommonMark does.)