### PR TITLE
db.json: add twitter to standards

### DIFF
--- a/db.json
+++ b/db.json
@@ -25,7 +25,8 @@
           "review_draft_schedule": [
             6,
             12
-          ]
+          ],
+          "twitter": "compatstandard"
         }
       ]
     },
@@ -70,7 +71,8 @@
           "review_draft_schedule": [
             6,
             12
-          ]
+          ],
+          "twitter": "consolelog"
         }
       ]
     },
@@ -99,7 +101,8 @@
           "review_draft_schedule": [
             6,
             12
-          ]
+          ],
+          "twitter": "thedomstandard"
         }
       ]
     },
@@ -128,7 +131,8 @@
           "review_draft_schedule": [
             6,
             12
-          ]
+          ],
+          "twitter": "encodings"
         }
       ]
     },
@@ -157,7 +161,8 @@
           "review_draft_schedule": [
             6,
             12
-          ]
+          ],
+          "twitter": "fetchstandard"
         }
       ]
     },
@@ -186,7 +191,8 @@
           "review_draft_schedule": [
             1,
             7
-          ]
+          ],
+          "twitter": "fullscreenapi"
         }
       ]
     },
@@ -231,7 +237,8 @@
           "review_draft_schedule": [
             1,
             7
-          ]
+          ],
+          "twitter": "htmlstandard"
         }
       ]
     },
@@ -264,7 +271,8 @@
           "review_draft_schedule": [
             1,
             7
-          ]
+          ],
+          "twitter": "infrastandard"
         }
       ]
     },
@@ -293,7 +301,8 @@
           "review_draft_schedule": [
             1,
             7
-          ]
+          ],
+          "twitter": "mimesniff"
         }
       ]
     },
@@ -322,7 +331,8 @@
           "review_draft_schedule": [
             1,
             7
-          ]
+          ],
+          "twitter": "notifyapi"
         }
       ]
     },
@@ -351,7 +361,8 @@
           "review_draft_schedule": [
             2,
             8
-          ]
+          ],
+          "twitter": "quirksstandard"
         }
       ]
     },
@@ -380,7 +391,8 @@
           "review_draft_schedule": [
             2,
             8
-          ]
+          ],
+          "twitter": "storagestandard"
         }
       ]
     },
@@ -417,7 +429,8 @@
           "review_draft_schedule": [
             2,
             8
-          ]
+          ],
+          "twitter": "streamsstandard"
         }
       ]
     },
@@ -446,7 +459,8 @@
           "review_draft_schedule": [
             2,
             8
-          ]
+          ],
+          "twitter": "urlstandard"
         }
       ]
     },
@@ -475,7 +489,8 @@
           "review_draft_schedule": [
             2,
             8
-          ]
+          ],
+          "twitter": "xhrstandard"
         }
       ]
     }

--- a/db.py
+++ b/db.py
@@ -49,6 +49,7 @@ def normalize_person(editor):
 def normalize_workstream_standard(document):
     output = normalize_workstream_standard_or_idea(document)
     output["review_draft_schedule"] = document["review_draft_schedule"]
+    output["twitter"] = document["twitter"]
     return output
 
 def normalize_workstream_standard_or_idea(document):


### PR DESCRIPTION
This can be used to find the Twitter account of a standard, which is useful for https://github.com/whatwg/meta/issues/109. We can also use it to advertise these accounts, e.g., on spec.whatwg.org.