### PR TITLE
Add WebSockets Standard

### DIFF
--- a/db.json
+++ b/db.json
@@ -210,7 +210,7 @@
         {
           "name": "HTML",
           "href": "https://html.spec.whatwg.org/multipage/",
-          "description": "The HTML Standard is a kitchen sink full of technologies for the web. It includes the core markup language for the web, HTML, as well as numerous APIs like Web Sockets, Web Workers, `localStorage`, etc.",
+          "description": "The HTML Standard is a kitchen sink full of technologies for the web. It includes the core markup language for the web, HTML, as well as numerous APIs like Web Workers, `localStorage`, etc.",
           "authors": [
             {
               "name": "Anne van Kesteren",
@@ -239,6 +239,23 @@
             7
           ],
           "twitter": "htmlstandard"
+        },
+        {
+          "name": "WebSockets",
+          "href": "https://websockets.spec.whatwg.org/",
+          "description": "The WebSockets Standard provides APIs to enable web applications to maintain bidirectional communications with server-side processes.",
+          "authors": [
+            {
+              "name": "Adam Rice",
+              "email": "ricea@chromium.org"
+            }
+          ],
+          "reference": "WEBSOCKETS",
+          "review_draft_schedule": [
+            3,
+            9
+          ],
+          "twitter": "whatsockets"
         }
       ]
     },

--- a/db.py
+++ b/db.py
@@ -15,7 +15,7 @@ def normalize_internal(input):
     return string + "\n"
 
 def normalize(input):
-    open("db.json", "w").write(normalize_internal(input))
+    open("db.json", "w", encoding="utf-8").write(normalize_internal(input))
 
 def normalize_db(db):
     for (name, normalize_algorithm, sort_key) in [

--- a/db.py
+++ b/db.py
@@ -96,7 +96,7 @@ def main():
     if command not in ["validate", "normalize"]:
         usage()
     else:
-        input = open("db.json", "r").read()
+        input = open("db.json", "r", encoding="utf-8").read()
         if command == "validate":
             validate(input)
         elif command == "normalize":


### PR DESCRIPTION
See https://github.com/whatwg/meta/issues/202.

Also fixes db.py to work on environments where the default encoding is not UTF-8, i.e., on Windows.

I chose 3,9 as the review draft schedule as that seems to be the new time we're lumping things at (for Web IDL and TestUtils).

Do not merge quite yet; the DNS propagation seems to be still in progress, so https://websockets.spec.whatwg.org does not work at the moment.

Also remember we need to re-deploy participate.whatwg.org manually per https://github.com/whatwg/sg/issues/171.