### PR TITLE
Clarify and exemplify non-normative changes

### DIFF
--- a/Working Mode.md
+++ b/Working Mode.md
@@ -49,7 +49,11 @@ Additions to the standard can also be proposed as issues. However, the process f
 
 ### Non-normative issues
 
-Changes of editorial nature can be made, accepted, or rejected by the editor without discussion.
+Changes of editorial nature, or which only impact non-normative text, can be made, accepted, or rejected by the editor without discussion.
+
+The same applies for changes which are (in the editor's judgement) obvious bug fixes, where the standard failed to reflect the clearly-intended behavior in its normative text.
+
+EXAMPLE: Some representative cases of such "obvious bug fixes" are [restoring an accidentally-deleted step](https://github.com/whatwg/html/pull/9980), [correcting a value to match the declared IDL type signature](https://github.com/whatwg/urlpattern/pull/213), or [passing a value through the algorithms that expect it](https://github.com/whatwg/streams/pull/1300).
 
 ## Changes
 

--- a/Working Mode.md
+++ b/Working Mode.md
@@ -55,6 +55,8 @@ The same applies for changes which are (in the editor's judgement) obvious bug f
 
 EXAMPLE: Some representative cases of such "obvious bug fixes" are [restoring an accidentally-deleted step](https://github.com/whatwg/html/pull/9980), [correcting a value to match the declared IDL type signature](https://github.com/whatwg/urlpattern/pull/213), or [passing a value through the algorithms that expect it](https://github.com/whatwg/streams/pull/1300).
 
+NOTE: if implementations disagree on a behavior, then even if the correct fix feels obvious, it's better to start a wider discussion and take the fix through the normative change process.
+
 ## Changes
 
 Each normative change made to the standard needs to meet the following criteria:


### PR DESCRIPTION
The previous text implied that non-normative changes were the same as editorial changes. At least using the definition of "editorial" in https://github.com/whatwg/meta/blob/main/COMMITTING.md#title-prefixes, this is not correct; non-normative changes are a superset of editorial changes.

Kudos to @jeremyroman for pointing this out.