### PR TITLE
Change the Compression Standard's Twitter account

### DIFF
--- a/db.json
+++ b/db.json
@@ -456,7 +456,7 @@
             4,
             10
           ],
-          "twitter": "compressionstandard"
+          "twitter": "compressionapi"
         },
         {
           "name": "Streams",


### PR DESCRIPTION
"compressionstandard" was too long, so we had to get "compressionapi" instead.