### PR TITLE
Add Matt Reynolds as editor of Peripherals workstream

### DIFF
--- a/db.json
+++ b/db.json
@@ -382,6 +382,10 @@
         {
           "name": "Reilly Grant",
           "email": "reillyg@google.com"
+        },
+        {
+          "name": "Matt Reynolds",
+          "email": "mattreynolds@google.com"
         }
       ],
       "standards": [
@@ -408,8 +412,8 @@
           "description": "The WebHID Standard defines an API for web applications to provide user access to peripherals via the HID standard.",
           "authors": [
             {
-              "name": "Reilly Grant",
-              "email": "reillyg@google.com"
+              "name": "Matt Reynolds",
+              "email": "mattreynolds@google.com"
             }
           ],
           "reference": "WEBHID",
@@ -425,8 +429,8 @@
           "description": "The WebNFC Standard defines an API for web applications to provide user access to peripherals via the NFC standard.",
           "authors": [
             {
-              "name": "Reilly Grant",
-              "email": "reillyg@google.com"
+              "name": "Matt Reynolds",
+              "email": "mattreynolds@google.com"
             }
           ],
           "reference": "WEBNFC",


### PR DESCRIPTION
Reilly and Matt will share the editor role and split authorship of the standards.