### PR TITLE
Positive standards position counts as implementer interest

### DIFF
--- a/Stages.md
+++ b/Stages.md
@@ -12,7 +12,7 @@ These checkpoints are modeled loosely on the [TC39 process](https://tc39.es/proc
 
 * <dfn>Stage</dfn>: each successive stage is closer to an integrated [Contribution](./IPR%20Policy.md#21-contribution) and interoperable implementation. These stages are tracked on the issues in the relevant WHATWG GitHub repository, using labels (“stage: 0”, “stage: 1”, etc.). The stages are described in the Stages overview below.
 * <dfn>Browser engine</dfn>: an independent implementation of the web platform (i.e., Chromium, Gecko, and WebKit at present).
-* <dfn>Implementer interest</dfn>: a direct signal from a browser engine — such as a feature being on the roadmap to implement, or an official positive standards position — as defined in the [Working Mode](./Working%20Mode.md#additions).
+* <dfn>Implementer interest</dfn>: a direct signal from a browser engine, as defined in the [Working Mode](./Working%20Mode.md#additions).
 * <dfn>Browser engine representatives</dfn>: persons delegated by a browser engine to indicate implementer interest.
 
 ## Process

--- a/Stages.md
+++ b/Stages.md
@@ -12,7 +12,7 @@ These checkpoints are modeled loosely on the [TC39 process](https://tc39.es/proc
 
 * <dfn>Stage</dfn>: each successive stage is closer to an integrated [Contribution](./IPR%20Policy.md#21-contribution) and interoperable implementation. These stages are tracked on the issues in the relevant WHATWG GitHub repository, using labels (“stage: 0”, “stage: 1”, etc.). The stages are described in the Stages overview below.
 * <dfn>Browser engine</dfn>: an independent implementation of the web platform (i.e., Chromium, Gecko, and WebKit at present).
-* <dfn>Implementer interest</dfn>: a direct signal from a browser engine that a feature is on the roadmap to implement, as defined in the [Working Mode](./Working%20Mode.md#additions).
+* <dfn>Implementer interest</dfn>: a direct signal from a browser engine — such as a feature being on the roadmap to implement, or an official positive standards position — as defined in the [Working Mode](./Working%20Mode.md#additions).
 * <dfn>Browser engine representatives</dfn>: persons delegated by a browser engine to indicate implementer interest.
 
 ## Process

--- a/Working Mode.md
+++ b/Working Mode.md
@@ -83,7 +83,7 @@ Any change that represents an addition needs to meet these additional criteria:
 
 Additionally, the following are strongly recommended:
 
-* The support from implementers should be of the form “we would like to implement this soon” and not just “this seems like a reasonable idea”.
+* The support from implementers should be an official signal, such as a statement of intent to implement or an official positive standards position from the browser engine. It should not just be informal or casual comments (e.g., “this seems like a reasonable idea”).
 * There should be no strong implementer objections to the new feature.
 * There should already be a prototype implementation or one being worked on side-by-side with the change to the standard.
 * New features should be something that cannot be done today or are such a common trend in libraries that standardizing them helps lots of people. Alternatively, the “new” feature could actually be a legacy feature that was not yet standardized, which is now being standardized. (Legacy features are often hard to remove due to web compatibility; standardizing and testing them helps improve interoperability and enables competition and refactoring.)

--- a/Working Mode.md
+++ b/Working Mode.md
@@ -61,7 +61,7 @@ NOTE: if implementations disagree on a behavior, then even if the correct fix fe
 
 Each normative change made to the standard needs to meet the following criteria:
 
-* It must have support from implementers.
+* It must have support from implementers. A positive standards position meets this bar, as do comments elsewhere by implementers.
 * It should have corresponding test changes, either in the form of new tests or modifications to existing tests.
 * Implementations bugs must be filed for each user agent that fails tests. (This is each user agent that doesn’t match the proposed changes. If the test changes are not adequate to reveal that, but it’s known through other means, the tests should be improved first.)
 * It should have been reviewed by one or more members of the community.
@@ -83,7 +83,7 @@ Any change that represents an addition needs to meet these additional criteria:
 
 Additionally, the following are strongly recommended:
 
-* The support from implementers should be of the form “we would like to implement this soon”, and not just “this seems like a reasonable idea”. A positive standards position meets this bar, as do comments elsewhere by implementers.
+* The support from implementers should be of the form “we would like to implement this soon”, and not just “this seems like a reasonable idea”.
 * There should be no strong implementer objections to the new feature.
 * There should already be a prototype implementation or one being worked on side-by-side with the change to the standard.
 * New features should be something that cannot be done today or are such a common trend in libraries that standardizing them helps lots of people. Alternatively, the “new” feature could actually be a legacy feature that was not yet standardized, which is now being standardized. (Legacy features are often hard to remove due to web compatibility; standardizing and testing them helps improve interoperability and enables competition and refactoring.)

--- a/Working Mode.md
+++ b/Working Mode.md
@@ -83,7 +83,7 @@ Any change that represents an addition needs to meet these additional criteria:
 
 Additionally, the following are strongly recommended:
 
-* The support from implementers should be an official signal, such as a statement of intent to implement or an official positive standards position from the browser engine. It should not just be informal or casual comments (e.g., “this seems like a reasonable idea”).
+* The support from implementers should be of the form “we would like to implement this soon”, and not just “this seems like a reasonable idea”. A positive standards position meets this bar, as do comments elsewhere by implementers.
 * There should be no strong implementer objections to the new feature.
 * There should already be a prototype implementation or one being worked on side-by-side with the change to the standard.
 * New features should be something that cannot be done today or are such a common trend in libraries that standardizing them helps lots of people. Alternatively, the “new” feature could actually be a legacy feature that was not yet standardized, which is now being standardized. (Legacy features are often hard to remove due to web compatibility; standardizing and testing them helps improve interoperability and enables competition and refactoring.)

--- a/Working Mode.md
+++ b/Working Mode.md
@@ -83,7 +83,7 @@ Any change that represents an addition needs to meet these additional criteria:
 
 Additionally, the following are strongly recommended:
 
-* The support from implementers should be of the form “we would like to implement this soon”, and not just “this seems like a reasonable idea”.
+* The support from implementers should be of the form “we would like to implement this soon” and not just “this seems like a reasonable idea”.
 * There should be no strong implementer objections to the new feature.
 * There should already be a prototype implementation or one being worked on side-by-side with the change to the standard.
 * New features should be something that cannot be done today or are such a common trend in libraries that standardizing them helps lots of people. Alternatively, the “new” feature could actually be a legacy feature that was not yet standardized, which is now being standardized. (Legacy features are often hard to remove due to web compatibility; standardizing and testing them helps improve interoperability and enables competition and refactoring.)


### PR DESCRIPTION
This PR formalizes a browser's official standards position's relationship to implementer interest. Specifically, a positive standards position counts as implementer interest.